### PR TITLE
Adds endpoint for client.queryStorageDeal

### DIFF
--- a/API.md
+++ b/API.md
@@ -527,10 +527,7 @@ console.log(storageDeal)
   "proofInfo":
     {
       "sectorID": 1,
-      "commitmentMessage":
-        {
-          "/":  "zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
-        },
+      "commitmentMessage": "zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R",
       "pieceInclusionProof":  "EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
     },
   "signature": "c2lnbmF0dXJycmVlZQ=="

--- a/API.md
+++ b/API.md
@@ -495,6 +495,7 @@ const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId
 ## `client.queryStorageDeal`
 
 > Query a storage deal's status
+
 ### `client.queryStorageDeal(dealCid, [options])`
 
 #### Parameters
@@ -520,22 +521,19 @@ console.log(storageDeal)
 
 /*
 {
-  "State":7,
-  "Message":"",
-  "ProposalCid":
+  "state": 7,
+  "message": "",
+  "proposalCid": "zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT",
+  "proofInfo":
     {
-      "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
-    },
-  "ProofInfo":
-    {
-      "SectorID":1,
-      "CommitmentMessage":
+      "sectorID": 1,
+      "commitmentMessage":
         {
-          "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
+          "/":  "zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
         },
-      "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+      "pieceInclusionProof":  "EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
     },
-  "Signature":"c2lnbmF0dXJycmVlZQ=="
+  "signature": "c2lnbmF0dXJycmVlZQ=="
 }
 */
 ```

--- a/API.md
+++ b/API.md
@@ -13,7 +13,7 @@
 * [client.listAsks](#clientlistasks)
 * [client.payments](#clientpayments)
 * [client.proposeStorageDeal](#clientproposestoragedeal)
-* client.queryStorageDeal
+* [client.queryStorageDeal](#clientquerystoragedeal)
 * [config.get](#configget)
 * [config.set](#configset)
 * [dag.get](#dagget)
@@ -491,6 +491,55 @@ const storageDealProposal = await fc.client.proposeStorageDeal(miner, cid, askId
 }
 */
 ```
+
+## `client.queryStorageDeal`
+
+> Query a storage deal's status
+### `client.queryStorageDeal(dealCid, [options])`
+
+#### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| dealCid | `String` | CID of deal to query |
+| options | `Object` | Optional options |
+| options.signal | [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) | A signal that can be used to abort the request |
+
+#### Returns
+
+| Type | Description |
+|------|-------------|
+| `Promise<Object>` | Storage deal |
+
+#### Example
+
+```js
+const dealCid = 'zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT'
+const storageDeal = await fc.client.queryStorageDeal(dealCid)
+console.log(storageDeal)
+
+/*
+{
+  "State":7,
+  "Message":"",
+  "ProposalCid":
+    {
+      "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
+    },
+  "ProofInfo":
+    {
+      "SectorID":1,
+      "CommitmentMessage":
+        {
+          "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
+        },
+      "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+    },
+  "Signature":"c2lnbmF0dXJycmVlZQ=="
+}
+*/
+```
+
 
 ## `config.get`
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ filecoin config api.accessControlAllowOrigin '["http://example.com"]'
 * [client.listAsks](API.md#clientlistasks)
 * [client.payments](API.md#clientpayments)
 * [client.proposeStorageDeal](API.md#clientproposestoragedeal)
-* client.queryStorageDeal
+* [client.queryStorageDeal](API.md#clientquerystoragedeal)
 * [config.get](API.md#configget)
 * [config.set](API.md#configset)
 * [dag.get](API.md#dagget)

--- a/src/cmd/client/query-storage-deal.js
+++ b/src/cmd/client/query-storage-deal.js
@@ -1,0 +1,14 @@
+const toUri = require('../../lib/multiaddr-to-uri')
+const { ok } = require('../../lib/fetch')
+
+module.exports = (fetch, config) => {
+  return async (cid, options) => {
+    options = options || {}
+
+    const url = `${toUri(config.apiAddr)}/api/client/query-storage-deal?arg=${encodeURIComponent(cid)}`
+    const res = await ok(fetch(url, { signal: options.signal }))
+
+    const data = await res.json()
+    return data
+  }
+}

--- a/src/cmd/client/query-storage-deal.js
+++ b/src/cmd/client/query-storage-deal.js
@@ -1,5 +1,6 @@
 const toUri = require('../../lib/multiaddr-to-uri')
 const { ok } = require('../../lib/fetch')
+const toCamel = require('../../lib/to-camel')
 
 module.exports = (fetch, config) => {
   return async (cid, options) => {
@@ -8,7 +9,16 @@ module.exports = (fetch, config) => {
     const url = `${toUri(config.apiAddr)}/api/client/query-storage-deal?arg=${encodeURIComponent(cid)}`
     const res = await ok(fetch(url, { signal: options.signal }))
 
-    const data = await res.json()
-    return data
+    const storageDeal = toCamel(await res.json())
+
+    if (storageDeal.proposalCid) {
+      storageDeal.proposalCid = storageDeal.proposalCid['/']
+    }
+
+    if (storageDeal.proofInfo) {
+      storageDeal.proofInfo = toCamel(storageDeal.proofInfo)
+    }
+
+    return storageDeal
   }
 }

--- a/src/cmd/client/query-storage-deal.js
+++ b/src/cmd/client/query-storage-deal.js
@@ -19,6 +19,10 @@ module.exports = (fetch, config) => {
       storageDeal.proofInfo = toCamel(storageDeal.proofInfo)
     }
 
+    if (storageDeal.proofInfo && storageDeal.proofInfo.commitmentMessage) {
+      storageDeal.proofInfo.commitmentMessage = storageDeal.proofInfo.commitmentMessage['/']
+    }
+
     return storageDeal
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,8 @@ module.exports = (fetch, config) => {
       import: require('./cmd/client/import')(fetch, config),
       listAsks: require('./cmd/client/list-asks')(fetch, config),
       payments: require('./cmd/client/payments')(fetch, config),
-      proposeStorageDeal: require('./cmd/client/propose-storage-deal')(fetch, config)
+      proposeStorageDeal: require('./cmd/client/propose-storage-deal')(fetch, config),
+      queryStorageDeal: require('./cmd/client/query-storage-deal')(fetch, config)
     },
     config: {
       get: require('./cmd/config/get')(fetch, config),

--- a/test/unit/cmd/client/query-storage-deal.fixtures.json
+++ b/test/unit/cmd/client/query-storage-deal.fixtures.json
@@ -1,0 +1,18 @@
+{
+  "State":7,
+  "Message":"",
+  "ProposalCid":
+    {
+      "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
+    },
+  "ProofInfo":
+    {
+      "SectorID":1,
+      "CommitmentMessage":
+        {
+          "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
+        },
+      "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+    },
+  "Signature":"c2lnbmF0dXJycmVlZQ=="
+}

--- a/test/unit/cmd/client/query-storage-deal.test.js
+++ b/test/unit/cmd/client/query-storage-deal.test.js
@@ -1,0 +1,31 @@
+const test = require('ava')
+const Filecoin = require('../../../../src')
+
+test('should list the storage deal info for a particular cid', async t => {
+  const cid = "zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF"
+  const storageDeal = {
+    "State":7,
+    "Message":"",
+    "ProposalCid":
+      {
+        "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
+      },
+    "ProofInfo":
+      {
+        "SectorID":1,
+        "CommitmentMessage":
+          {
+            "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
+          },
+        "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+      },
+    "Signature":"c2lnbmF0dXJycmVlZQ=="
+  }
+
+  const fetch = () => ({ ok: true, json: () => storageDeal })
+  const fc = Filecoin(fetch)
+
+  const res = await fc.client.queryStorageDeal(cid)
+
+  t.is(storageDeal, res)
+})

--- a/test/unit/cmd/client/query-storage-deal.test.js
+++ b/test/unit/cmd/client/query-storage-deal.test.js
@@ -1,31 +1,29 @@
 const test = require('ava')
 const Filecoin = require('../../../../src')
+const Fixtures = require('./query-storage-deal.fixtures.json')
 
 test('should list the storage deal info for a particular cid', async t => {
   const cid = "zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF"
-  const storageDeal = {
-    "State":7,
-    "Message":"",
-    "ProposalCid":
-      {
-        "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
-      },
-    "ProofInfo":
-      {
-        "SectorID":1,
-        "CommitmentMessage":
-          {
-            "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
-          },
-        "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
-      },
-    "Signature":"c2lnbmF0dXJycmVlZQ=="
-  }
 
-  const fetch = () => ({ ok: true, json: () => storageDeal })
+  const fetch = () => ({ ok: true, json: () => Fixtures })
   const fc = Filecoin(fetch)
 
   const res = await fc.client.queryStorageDeal(cid)
 
-  t.is(storageDeal, res)
+  const proofInfo = {
+    "sectorID": 1,
+    "commitmentMessage":
+      {
+        "/": "zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
+      },
+    "pieceInclusionProof": "EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+  }
+
+  t.deepEqual(res, {
+    state: 7,
+    message: '',
+    proposalCid: 'zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT',
+    proofInfo: proofInfo,
+    signature: 'c2lnbmF0dXJycmVlZQ=='
+  })
 })

--- a/test/unit/cmd/client/query-storage-deal.test.js
+++ b/test/unit/cmd/client/query-storage-deal.test.js
@@ -3,7 +3,7 @@ const Filecoin = require('../../../../src')
 const Fixtures = require('./query-storage-deal.fixtures.json')
 
 test('should list the storage deal info for a particular cid', async t => {
-  const cid = "zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF"
+  const cid = 'zDPWYqFCuTNxiwRkt1iDJWEy6qKPGCunMGHrP1ojsMrZDWKYsgzF'
 
   const fetch = () => ({ ok: true, json: () => Fixtures })
   const fc = Filecoin(fetch)
@@ -11,12 +11,9 @@ test('should list the storage deal info for a particular cid', async t => {
   const res = await fc.client.queryStorageDeal(cid)
 
   const proofInfo = {
-    "sectorID": 1,
-    "commitmentMessage":
-      {
-        "/": "zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
-      },
-    "pieceInclusionProof": "EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
+    sectorID: 1,
+    commitmentMessage: 'zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R',
+    pieceInclusionProof: 'EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=='
   }
 
   t.deepEqual(res, {


### PR DESCRIPTION
Adds endpoint to query a storage deal

Solves issue [#16 
](https://github.com/filecoin-project/js-filecoin-api-client/issues/16)

**Endpoint**
`/api/client/query-storage-deal`

**Description**
Query a storage deal's status

**Arguments**
* arg [string]: CID of deal to query Required: yes.

**Response**
On success, the call to this endpoint will return with 200 and the following body:

```
{
  "State":7,
  "Message":"",
  "ProposalCid":
    {
      "/":"zDPWYqFD8CNXu7Mo9qPSUANbTK2vi9vJBnvavF9S1pVGPHafVHpT"
    },
  "ProofInfo":
    {
      "SectorID":1,
      "CommitmentMessage":
        {
          "/":"zDPWYqFCtHkWNkE2p6t6TeV1sPP5kbnKc5ajUhMVV8xvrw1u5F1R"
        },
      "PieceInclusionProof":"EiAbbOy4pChsCYqFYA6qJaUJYStlnwYMdQPHZX7YBkVXDD6vgmGTPnWrcdA9M0oAXQCzOq735YKySLUoTI6pAw=="
    },
  "Signature":"c2lnbmF0dXJycmVlZQ=="
}
```

resolves #16